### PR TITLE
Improve lead validation for marketing dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,281 +1,157 @@
-#### It's a bird, it's a plane, it's... a self-hosted, pi-hole esque, DNS resolver
+# Marketing Performance Dashboard
 
-_serverless-dns_ is a Pi-Hole esque [content-blocking](https://github.com/serverless-dns/blocklists), serverless, stub DNS-over-HTTPS (DoH) and DNS-over-TLS (DoT) resolver. Runs out-of-the-box on [Cloudflare Workers](https://workers.dev), [Deno Deploy](https://deno.com/deploy), [Fastly Compute@Edge](https://www.fastly.com/products/edge-compute), and [Fly.io](https://fly.io/). Free tiers of all these services should be enough to cover 10 to 20 devices worth of DNS traffic per month.
+A full-stack MERN application for managing marketing campaigns and leads with rich analytics, built with Express, MongoDB, React (Vite), Tailwind CSS, Shadcn UI components, Recharts, and JWT authentication.
 
-### The RethinkDNS resolver
+## Features
 
-RethinkDNS runs `serverless-dns` in production at these endpoints:
+- 🔐 **Role-based authentication** (Admin & Data Entry) with JWT and secure password hashing.
+- 📊 **Admin analytics dashboard** with conversion trends, CPL/CPA metrics, and best campaign rankings.
+- 🗂️ **Campaign & lead management** including full CRUD flows, modal forms, and duplicate-lead prevention.
+- 🌗 **Modern UI/UX** built with Shadcn UI, Tailwind CSS, and responsive layouts, supporting light/dark themes.
+- 🔔 **Realtime feedback** using `react-hot-toast` notifications and loading states for a polished experience.
 
-| Cloud platform     | Server locations | Protocol    | Domain                    | Usage                                   |
-|--------------------|------------------|-------------|---------------------------|-----------------------------------------|
-| ⛅ Cloudflare Workers | 280+ ([ping](https://check-host.net/check-ping?host=https://sky.rethinkdns.com))           | DoH         | `sky.rethinkdns.com`    | [configure](https://rethinkdns.com/configure?p=doh)  |
-| 🦕 Deno Deploy        | 30+ ([ping](https://check-host.net/check-ping?host=https://deno.dev))                      | DoH         | _private beta_          |                                         |
-| ⏱️ Fastly Compute@Edge   | 80+ ([ping](https://check-host.net/check-ping?host=https://serverless-dns.edgecompute.app))| DoH         | _private beta_          |                                      |
-| 🪂 Fly.io             | 30+ ([ping](https://check-host.net/check-ping?host=https://max.rethinkdns.com))           | DoH and DoT | `max.rethinkdns.com`      | [configure](https://rethinkdns.com/configure?p=dot)  |
+## Project Structure
 
-Server-side processing takes from 0 milliseconds (ms) to 2ms (median), and end-to-end latency (varies across regions and networks) is between 10ms to 30ms (median).
-
-### Self-host
-
-Cloudflare Workers is the easiest platform to setup `serverless-dns`:
-
-[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/serverless-dns/serverless-dns)
-
-[![Deploy to Fastly](https://deploy.edgecompute.app/button)](https://deploy.edgecompute.app/deploy)
-
-For step-by-step instructions, refer:
-
-| Platform       | Difficulty | Runtime                                | Doc                                                                                     |
-| ---------------| ---------- | -------------------------------------- | --------------------------------------------------------------------------------------- |
-| ⛅ Cloudflare  | Easy       | [v8](https://v8.dev) _Isolates_        | [Hosting on Cloudflare Workers](https://docs.rethinkdns.com/dns/open-source#cloudflare) |
-| 🦕 Deno.com    | Moderate   | [Deno](https://deno.land) _Isolates_   | [Hosting on Deno.com](https://docs.rethinkdns.com/dns/open-source#deno-deploy)          |
-| ⏱️ Fastly Compute@Edge | Easy  | [Fastly JS](https://js-compute-reference-docs.edgecompute.app/)| [Hosting on Fastly Compute@Edge](https://docs.rethinkdns.com/dns/open-source#fastly) |
-| 🪂 Fly.io      | Hard       | [Node](https://nodejs.org) _MicroVM_   | [Hosting on Fly.io](https://docs.rethinkdns.com/dns/open-source#fly-io)                 |
-
-To setup blocklists, visit `https://<my-domain>.tld/configure` from your browser (it should load something similar to [RethinkDNS' _configure_ page](https://rethinkdns.com/configure)).
-
-For help or assistance, feel free to [open an issue](https://github.com/celzero/docs/issues) or [submit a patch](https://github.com/celzero/docs).
+```
+backend/    # Express API & MongoDB models
+frontend/   # Vite + React client application
+```
 
 ---
 
-### Development
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/serverless-dns/serverless-dns/badge)](https://securityscorecards.dev/viewer/?uri=github.com/serverless-dns/serverless-dns)
+## Getting Started
 
-#### Setup
+### Prerequisites
 
-Code:
-```bash
-# navigate to work dir
-cd /my/work/dir
+- Node.js 18+
+- npm 9+
+- MongoDB 6+ (local instance or connection string)
 
-# clone this repository
-git clone https://github.com/serverless-dns/serverless-dns.git
+### Environment Variables
 
-# navigate to serverless-dns
-cd ./serverless-dns
-```
-
-Node:
-```bash
-# install node v19+ via nvm, if required
-# https://github.com/nvm-sh/nvm#installing-and-updating
-wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-nvm install --lts
-
-# download dependencies
-npm i
-
-# (optional) update dependencies
-npm update
-
-# run serverless-dns on node
-./run n
-
-# run a clinicjs.org profiler
-./run n [cpu|fn|mem]
-```
-
-Deno:
-```bash
-# install deno.land v1.22+
-# https://github.com/denoland/deno/#install
-curl -fsSL https://deno.land/install.sh | sh
-
-# run serverless-dns on deno
-./run d
-```
-
-Fastly:
-```bash
-# install node v18+ via nvm, if required
-# install the Fastly CLI
-# https://developer.fastly.com/learning/tools/cli
-
-# run serverless-dns on Fastly Compute@Edge
-./run f
-```
-
-Wrangler:
-```bash
-# install Cloudflare Workers (cli) aka Wrangler
-# https://developers.cloudflare.com/workers/cli-wrangler/install-update
-npm i wrangler --save-dev
-
-# run serverless-dns on Cloudflare Workers (cli)
-# Make sure to setup Wrangler first:
-# https://developers.cloudflare.com/workers/cli-wrangler/authentication
-./run w
-
-# profile wrangler with Chrome DevTools
-# blog.cloudflare.com/profiling-your-workers-with-wrangler
-```
-
-#### Code style
-
-Commits on this repository enforces the Google JavaScript style guide (ref: [.eslintrc.cjs](.eslintrc.cjs)).
-A git `pre-commit` hook that runs linter (eslint) and formatter (prettier) on `.js` files. Use `git commit --no-verify`
-to bypass this hook.
-
-Pull requests are also checked for code style violations and fixed automatically where possible.
-
-#### Env vars
-
-Configure [`env.js`](src/core/env.js) if you need to tweak the defaults.
-For Cloudflare Workers, setup env vars in [`wrangler.toml`](wrangler.toml), instead.
-For Fastly Compute@Edge, setup env vars in [`fastly.toml`](fastly.toml), instead.
-
-#### Request flow
-
-1. The request/response flow: client <-> `src/server-[node|workers|deno]` <-> [`doh.js`](src/core/doh.js) <-> [`plugin.js`](src/core/plugin.js)
-2. The `plugin.js` flow: `user-op.js` -> `cache-resolver.js` -> `cc.js` -> `resolver.js`
-
-#### Auth
-
-serverless-dns supports authentication with an *alpha-numeric* bearer token for both DoH and DoT. For a token, `msg-key` (secret), append the output of `hex(hmac-sha256(msg-key|domain.tld), msg)` to `ACCESS_KEYS` env var in csv format. Note: `msg` is currently fixed to `sdns-public-auth-info`.
-
-1. DoH: place the `msg-key` at the end of the blockstamp, like so:
-`1:1:4AIggAABEGAgAA:<msg-key>` (here, `1` is the version, `1:4AIggAABEGAgAA`
-is the blockstamp, `<msg-key>` is the auth secret, and `:` is the delimiter).
-2. DoT: place the `msg-key` at the end of the SNI (domain-name) containing the blockstamp:
-`1-4abcbaaaaeigaiaa-<msg-key>` (here `1` is the version, `4abcbaaaaeigaiaa`
-is the blockstamp, `<msg-key>` is the auth secret, and `-` is the delimeter).
-
-If the intention is to use auth with DoT too, keep `msg-key` shorter (8 to 24 chars), since subdomains may only be 63 chars long in total.
-
-You can generate the access keys for your fork from `max.rethinkdns.com`, like so:
-```bash
-msgkey="ShortAlphanumericSecret"
-domain="my-serverless-dns-domain.tld"
-curl 'https://max.rethinkdns.com/genaccesskey?key='"$msgkey"'&dom='"$domain"
-# output
-# {"accesskey":["my-serverless-dns-domain.tld|deadbeefd3adb33fa2bb33fd3eadf084beef3b152beefdead49bbb2b33fdead83d3adbeefdeadb33f"],"context":"sdns-public-auth-info"}
-```
-
-#### Logs and Analytics
-
-serverless-dns can be setup to upload logs via Cloudflare *Logpush*.
-
-0. Setup a *Logpush* job:
-    ```bash
-    CF_ACCOUNT_ID=<hex-cloudflare-account-id>
-    CF_API_KEY=<api-key-with-logs-edit-permission-at-account-level>
-    R2_BUCKET=<r2-bucket-name>
-    R2_ACCESS_KEY=<r2-access-key-for-the-bucket>
-    R2_SECRET_KEY=<r2-secret-key-with-read-write-permissions>
-    # optional, setup a filter such that only logs form this worker ends up being pushed; but if you
-    # do not need a filter on Worker name (script-name), edit the "filter" field below accordingly.
-    SCRIPT_NAME=<name-of-the-worker-as-in-wrangler-toml>
-    # for more options, ref: developers.cloudflare.com/logs/get-started/api-configuration
-    # Logpush API with cURL: developers.cloudflare.com/logs/tutorials/examples/example-logpush-curl
-    # Available Logpull fields: developers.cloudflare.com/logs/reference/log-fields/account/workers_trace_events
-    curl -s -X POST "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/logpush/jobs" \
-        -H "Authorization: Bearer ${CF_API_KEY}" \
-        -H 'Content-Type: application/json' \
-        -d '{
-            "name": "dns-logpush",
-            "logpull_options": "fields=EventTimestampMs,Outcome,Logs,ScriptName&timestamps=rfc3339",
-            "destination_conf": "r2://'"$R2_BUCKET"'/{DATE}?access-key-id='"${R2_ACCESS_KEY}"'&secret-access-key='"${R2_SECRET_KEY}"'&account-id='"{$CF_ACCOUNT_ID}"',
-            "dataset": "workers_trace_events",
-            "filter": "{\"where\":{\"and\":[{\"key\":\"ScriptName\",\"operator\":\"contains\",\"value\":\"'"${SCRIPT_NAME}"'\"},{\"key\":\"Outcome\",\"operator\":\"eq\",\"value\":\"ok\"}]}}",
-            "enabled": true,
-            "frequency": "low"
-        }'
-    ```
-1. Set `wrangler.toml` property `logpush = true`, which enables *Logpush*.
-2. (Optional) env var `LOG_LEVEL = "logpush"`, which raises the log-level such that only *request* and error logs are emitted.
-3. (Optional) Set env var `LOGPUSH_SRC = "csv,of,subdomains"`, which makes [`log-pusher.js`](./src/plugins/observability/log-pusher.js) emit *request* logs only if Workers `hostname` contains one of the subdomains.
-
-Logs published to R2 can be retrieved either using [R2 Workers](https://developers.cloudflare.com/r2/data-access/workers-api/workers-api-usage), the [R2 API](https://developers.cloudflare.com/r2/data-access/s3-api/api), or the [Logpush API](https://developers.cloudflare.com/logs/r2-log-retrieval).
-
-Workers Analytics, if enabled, is pushed against a log-key, `lid`, which if unspecified is set to hostname of the serverless deployment with periods, `.`, replaced with underscores, `_`. Auth must be setup when querying for Analytics via the API which returns a json; ex: `https://max.rethinkdns.com/1:<optional-stamp>:<msg-key>/analytics?t=<time-interval-in-mins>&f=<field-name>`. Possible `fields` are `ip` (client ip), `qname` (dns query name), `region` (resolver region), `qtype` (dns query type), `dom` (top-level domains), `ansip` (dns answer ips), and `cc` (ans ip country codes).
-
-Log capture and analytics isn't yet implemented for Fly and Deno Deploy.
-
-----
-
-#### A note about runtimes
-
-Deno Deploy (cloud) and Deno (the runtime) do not expose the same API surface (for example, Deno Deploy only
-supports HTTP/S server-listeners; whereas, Deno suports raw TCP/UDP/TLS in addition to plain HTTP and HTTP/S).
-
-Except on Node, `serverless-dns` uses DoH upstreams defined by env vars, `CF_DNS_RESOLVER_URL` / `CF_DNS_RESOLVER_URL_2`.
-On Node, the default DNS upstream is `1.1.1.2` ([ref](https://github.com/serverless-dns/serverless-dns/blob/15f628460/src/commons/dnsutil.js#L28)) or the recursive DNS resolver at `fdaa::3` when running on Fly.io.
-
-The entrypoints for Node and Deno are [`src/server-node.js`](src/server-node.js), [`src/server-deno.ts`](src/server-deno.ts) respectively,
-and both listen for TCP-over-TLS, HTTP/S connections; whereas, the entrypoint for Cloudflare Workers, which only listens over HTTP (cli) or
-over HTTP/S (prod), is [`src/server-workers.js`](src/server-workers.js); and for Fastly its [`src/server-fastly.js`](src/server-fastly.js).
-
-Local (non-prod) setups on Node, `key` (private) and `cert` (public chain) files, by default, are read from
-paths defined in env vars, `TLS_KEY_PATH` and `TLS_CRT_PATH`.
-
-Whilst for prod setup on Node (on Fly.io), either `TLS_OFFLOAD` must be set to `true` or `key` and `cert` _must_ be
-_base64_ encoded in env var `TLS_CERTKEY` ([ref](https://github.com/serverless-dns/serverless-dns/blob/f57c579/src/core/node/config.js#L61-L92)), like so:
+Copy the provided examples and update them with your own secrets.
 
 ```bash
-# EITHER: offload tls to fly.io and set tls_offload to true
-TLS_OFFLOAD="true"
-# OR: base64 representation of both key (private) and cert (public chain)
-TLS_CERTKEY="KEY=b64_key_content\nCRT=b64_cert_content"
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
 ```
 
-For Deno, `key` and `cert` files are read from paths defined in env vars, `TLS_KEY_PATH` and `TLS_CRT_PATH` ([ref](https://github.com/serverless-dns/serverless-dns/blob/270d1a3c/src/server-deno.ts#L32-L35)).
+`backend/.env`
+```
+PORT=5000
+MONGO_URI=mongodb://localhost:27017/marketing_dashboard
+JWT_SECRET=replace-with-strong-secret
+```
 
-_Process_ bringup is different for each of these runtimes: For Node, [`src/core/node/config.js`](src/core/node/config.js) governs the _bringup_;
-while for Deno, it is [`src/core/deno/config.ts`](src/core/deno/config.ts), and for Workers it is [`src/core/workers/config.js`](src/core/workers/config.js).
-[`src/system.js`](src/system.js) pub-sub co-ordinates the _bringup_ phase among various modules.
+`frontend/.env`
+```
+VITE_API_URL=http://localhost:5000/api
+```
 
-On Node and Deno, in-process DNS caching is backed by [`@serverless-dns/lfu-cache`](https://github.com/serverless-dns/lfu-cache); Cloudflare Workers is backed by both [Cache Web API](https://developers.cloudflare.com/workers/runtime-apis/cache) and
-in-process lfu caches. To disable caching altogether on all three platfroms, set env var, `PROFILE_DNS_RESOLVES=true`.
+### Install Dependencies
 
-#### Cloud
-
-Cloudflare Workers, and Deno Deploy are ephemeral, as in, the "process" that serves client requests is not long-lived,
-and in fact, two back-to-back requests may be served by two different [_isolates_](https://developers.cloudflare.com/workers/learning/how-workers-works) ("processes"). Fastly Compute@Edge is the also ephemeral but does not use isolates, instead Fastly creates and destroys a [wasmtime](https://wasmtime.dev/) sandbox for each request. Resolver on Fly.io, running Node, is backed by [persistent VMs](https://fly.io/blog/docker-without-docker/) and is hence longer-lived,
-like traditional "serverfull" environments.
-
-For Deno Deploy, the code-base is bundled up in a single javascript file with `deno bundle` and then handed off
-to Deno.com.
-
-Cloudflare Workers build-time and runtime configurations are defined in [`wrangler.toml`](wrangler.toml).
-[Webpack5 bundles the files](webpack.config.cjs) in an ESM module which is then uploaded to Cloudflare by _Wrangler_.
-
-Fastly Compute@Edge build-time and runtime configurations are defined in [`fastly.toml`](fastly.toml).
-[Webpack5 bundles the files](webpack.fastly.cjs) in an ESM module which is then compiled to WASM by `npx js-compute-runtime`
-and subsequently packaged and published to Fastly Compute@Edge with the _Fastly CLI_.
-
-For Fly.io, which runs Node, the runtime directives are defined in [`fly.toml`](fly.toml) (used by `dev` and `live` deployment-types),
-while deploy directives are in [`node.Dockerfile`](node.Dockerfile). [`flyctl`](https://fly.io/docs/flyctl) accordingly sets
-up `serverless-dns` on Fly.io's infrastructure.
+From the repository root, install the backend and frontend packages.
 
 ```bash
-# build and deploy for cloudflare workers.dev
-npm run build
-# usually, env-name is prod
-npx wrangler publish [-e <env-name>]
+cd backend
+npm install
 
-# bundle, build, and deploy for fastly compute@edge
-# developer.fastly.com/reference/cli/compute/publish
-fastly compute publish
-
-# build and deploy to fly.io
-npm run build:fly
-flyctl deploy --dockerfile node.Dockerfile --config <fly.toml> [-a <app-name>] [--image-label <some-uniq-label>]
+cd ../frontend
+npm install
 ```
 
-For deploys offloading TLS termination to Fly.io (`B1` deployment-type), the runtime directives are instead defined in
-[`fly.tls.toml`](fly.tls.toml), which sets up HTTP2 Cleartext and HTTP/1.1 on port `443`, and DNS over TCP on port `853`.
+### Run the Development Servers
 
-Ref: _[github/workflows](.github/workflows)_.
+In separate terminals:
 
-### Blocklists
+```bash
+# API server
+cd backend
+npm run dev
 
-190+ blocklists are compressed in a _Succinct Radix Trie_ ([based on Steve Hanov's impl](https://stevehanov.ca/blog/?id=120)) with modifications
-to speed up string search ([`lookup`](https://github.com/serverless-dns/trie/blob/965007a5c/src/ftrie.js#L378-L484)) at the expense of "succintness". The blocklists are versioned
-with unix timestamp (defined in `src/basicconfig.json` downloaded by [`pre.sh`](src/build/pre.sh)), which is generated once every week, but we'd like to generate 'em daily / hourly,
-if possible [see](https://github.com/serverless-dns/blocklists/issues/19)), and hosted on Cloudflare R2 (env var: `CF_BLOCKLIST_URL`).
+# React client
+cd frontend
+npm run dev
+```
 
-`serverless-dns` downloads [3 blocklist files](https://github.com/serverless-dns/serverless-dns/blob/15f62846/src/core/node/blocklists.js#L14-L16)
-required to setup the radix-trie during runtime bring-up or, downloads them [lazily](https://github.com/serverless-dns/serverless-dns/blob/02f9e5bf/src/plugins/dns-op/resolver.js#L167),
-when serving a DNS request.
+The React app will be available on `http://localhost:5173` and the API on `http://localhost:5000`.
 
-`serverless-dns` compiles around ~13M entries (as of Jan 2023) from around 190+ blocklists. These are defined in the [serverless-dns/blocklists](https://github.com/serverless-dns/blocklists) repository.
+### Seed an Admin User
+
+Use the registration form (`/register`) to create the initial admin account. Afterwards, admins can create additional Admin or Data Entry users through the same form.
+
+---
+
+## Available Scripts
+
+### Backend (`backend` directory)
+
+- `npm run dev` – Start the API with hot reload via nodemon.
+- `npm start` – Start the API in production mode.
+- `npm run lint` – Lint the backend codebase using ESLint.
+
+### Frontend (`frontend` directory)
+
+- `npm run dev` – Launch the Vite development server.
+- `npm run build` – Produce a production build.
+- `npm run preview` – Preview the production build locally.
+
+---
+
+## API Overview
+
+All endpoints are prefixed with `/api`.
+
+| Method | Endpoint                | Description                                    |
+| ------ | ----------------------- | ---------------------------------------------- |
+| POST   | `/auth/register`        | Register a new user and receive a JWT token.   |
+| POST   | `/auth/login`           | Log in with email/password and receive a JWT.  |
+| GET    | `/auth/me`              | Fetch current authenticated user.              |
+| GET    | `/campaigns`            | List campaigns (auth required).                |
+| POST   | `/campaigns`            | Create a campaign (auth required).             |
+| PUT    | `/campaigns/:id`        | Update a campaign (auth required).             |
+| DELETE | `/campaigns/:id`        | Remove a campaign (auth required).             |
+| GET    | `/leads`                | List leads (auth required).                    |
+| POST   | `/leads`                | Create a lead (prevents duplicate phone).      |
+| PUT    | `/leads/:id`            | Update a lead.                                 |
+| DELETE | `/leads/:id`            | Delete a lead.                                 |
+| GET    | `/dashboard/metrics`    | Admin-only analytics metrics endpoint.         |
+
+Use the `Authorization: Bearer <token>` header for all secured routes.
+
+---
+
+## Frontend Highlights
+
+- **State management** via a lightweight React context storing JWT/user data.
+- **Protected routes** with role-based access (React Router v6).
+- **Reusable Shadcn UI components** for forms, tables, dialogs, and buttons.
+- **Recharts visualizations** for lead growth and conversion analytics.
+- **Dark mode persistence** stored in `localStorage`.
+
+---
+
+## Production Build & Deployment
+
+1. Build both projects:
+   ```bash
+   cd backend && npm install && npm run build # (if build script added)
+   cd ../frontend && npm install && npm run build
+   ```
+2. Serve the backend with a Node.js process manager (PM2, Docker, etc.).
+3. Deploy the frontend build output (`frontend/dist`) via any static host (Vercel, Netlify, S3+CloudFront, etc.).
+4. Make sure `VITE_API_URL` points to the publicly accessible backend URL in production.
+
+---
+
+## Testing & Quality
+
+- Backend linting is provided via ESLint (`npm run lint`).
+- Vite will surface TypeScript/JSX errors during development.
+- Additional automated tests can be added using tools such as Jest or Vitest as needed.
+
+---
+
+## License
+
+This project is provided as part of a technical assessment and is not affiliated with the original `serverless-dns` codebase.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+PORT=5000
+MONGO_URI=mongodb://localhost:27017/marketing_dashboard
+JWT_SECRET=supersecretkey

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["standard"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "marketing-analytics-backend",
+  "version": "1.0.0",
+  "description": "Backend API for Marketing Performance Dashboard",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "nodemon src/index.js",
+    "start": "node src/index.js",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "express-async-errors": "^3.1.1",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.4.0",
+    "morgan": "^1.10.0"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-promise": "^6.1.1",
+    "nodemon": "^3.1.4"
+  }
+}

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,29 @@
+import 'express-async-errors'
+import express from 'express'
+import cors from 'cors'
+import morgan from 'morgan'
+import authRoutes from './routes/authRoutes.js'
+import campaignRoutes from './routes/campaignRoutes.js'
+import leadRoutes from './routes/leadRoutes.js'
+import dashboardRoutes from './routes/dashboardRoutes.js'
+import { errorHandler, notFound } from './middleware/errorHandler.js'
+
+const app = express()
+
+app.use(cors())
+app.use(express.json())
+app.use(morgan('dev'))
+
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok' })
+})
+
+app.use('/api/auth', authRoutes)
+app.use('/api/campaigns', campaignRoutes)
+app.use('/api/leads', leadRoutes)
+app.use('/api/dashboard', dashboardRoutes)
+
+app.use(notFound)
+app.use(errorHandler)
+
+export default app

--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose'
+
+export const connectDB = async () => {
+  const uri = process.env.MONGO_URI
+  if (!uri) {
+    throw new Error('MONGO_URI is not defined')
+  }
+  await mongoose.connect(uri, {
+    serverSelectionTimeoutMS: 5000
+  })
+  console.log('MongoDB connected')
+}

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,0 +1,58 @@
+import User from '../models/User.js'
+import { generateToken } from '../utils/token.js'
+
+export const register = async (req, res) => {
+  const { fullName, email, password, role } = req.body
+  if (!fullName || !email || !password) {
+    return res.status(400).json({ message: 'Full name, email and password are required' })
+  }
+
+  const existing = await User.findOne({ email })
+  if (existing) {
+    return res.status(409).json({ message: 'User already exists' })
+  }
+
+  const user = await User.create({ fullName, email, password, role })
+  const token = generateToken(user)
+  res.status(201).json({
+    user: {
+      id: user._id,
+      fullName: user.fullName,
+      email: user.email,
+      role: user.role
+    },
+    token
+  })
+}
+
+export const login = async (req, res) => {
+  const { email, password } = req.body
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password are required' })
+  }
+
+  const user = await User.findOne({ email })
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid credentials' })
+  }
+
+  const isMatch = await user.comparePassword(password)
+  if (!isMatch) {
+    return res.status(401).json({ message: 'Invalid credentials' })
+  }
+
+  const token = generateToken(user)
+  res.json({
+    user: {
+      id: user._id,
+      fullName: user.fullName,
+      email: user.email,
+      role: user.role
+    },
+    token
+  })
+}
+
+export const getProfile = async (req, res) => {
+  res.json({ user: req.user })
+}

--- a/backend/src/controllers/campaignController.js
+++ b/backend/src/controllers/campaignController.js
@@ -1,0 +1,30 @@
+import Campaign from '../models/Campaign.js'
+
+export const getCampaigns = async (req, res) => {
+  const campaigns = await Campaign.find().populate('owner', 'fullName email role').sort({ createdAt: -1 })
+  res.json(campaigns)
+}
+
+export const createCampaign = async (req, res) => {
+  const payload = { ...req.body, owner: req.user._id }
+  const campaign = await Campaign.create(payload)
+  res.status(201).json(campaign)
+}
+
+export const updateCampaign = async (req, res) => {
+  const { id } = req.params
+  const campaign = await Campaign.findByIdAndUpdate(id, req.body, { new: true, runValidators: true })
+  if (!campaign) {
+    return res.status(404).json({ message: 'Campaign not found' })
+  }
+  res.json(campaign)
+}
+
+export const deleteCampaign = async (req, res) => {
+  const { id } = req.params
+  const campaign = await Campaign.findByIdAndDelete(id)
+  if (!campaign) {
+    return res.status(404).json({ message: 'Campaign not found' })
+  }
+  res.json({ message: 'Campaign deleted' })
+}

--- a/backend/src/controllers/dashboardController.js
+++ b/backend/src/controllers/dashboardController.js
@@ -1,0 +1,99 @@
+import Campaign from '../models/Campaign.js'
+import Lead from '../models/Lead.js'
+
+export const getDashboardMetrics = async (req, res) => {
+  const { startDate, endDate } = req.query
+  const match = {}
+  if (startDate || endDate) {
+    match.createdAt = {}
+    if (startDate) {
+      match.createdAt.$gte = new Date(startDate)
+    }
+    if (endDate) {
+      match.createdAt.$lte = new Date(endDate)
+    }
+  }
+
+  const timeSeries = await Lead.aggregate([
+    { $match: match },
+    {
+      $group: {
+        _id: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } },
+        totalLeads: { $sum: 1 },
+        convertedLeads: {
+          $sum: {
+            $cond: [{ $eq: ['$status', 'Converted'] }, 1, 0]
+          }
+        }
+      }
+    },
+    { $sort: { _id: 1 } }
+  ])
+
+  const totals = timeSeries.reduce((acc, day) => {
+    acc.totalLeads += day.totalLeads
+    acc.convertedLeads += day.convertedLeads
+    return acc
+  }, { totalLeads: 0, convertedLeads: 0 })
+  totals.conversionRate = totals.totalLeads === 0 ? 0 : (totals.convertedLeads / totals.totalLeads) * 100
+
+  const campaignStats = await Lead.aggregate([
+    { $match: match },
+    {
+      $group: {
+        _id: '$sourceCampaign',
+        totalLeads: { $sum: 1 },
+        convertedLeads: {
+          $sum: {
+            $cond: [{ $eq: ['$status', 'Converted'] }, 1, 0]
+          }
+        }
+      }
+    }
+  ])
+
+  const campaignMap = campaignStats.reduce((acc, stat) => {
+    acc[stat._id?.toString() ?? 'unknown'] = stat
+    return acc
+  }, {})
+
+  const campaigns = await Campaign.find().select('name cost type startDate metrics')
+
+  const campaignMetrics = campaigns.map(campaign => {
+    const stat = campaignMap[campaign._id.toString()] || { totalLeads: 0, convertedLeads: 0 }
+    const cpl = stat.totalLeads === 0 ? null : campaign.cost / stat.totalLeads
+    const cpa = stat.convertedLeads === 0 ? null : campaign.cost / stat.convertedLeads
+    return {
+      id: campaign._id,
+      name: campaign.name,
+      type: campaign.type,
+      startDate: campaign.startDate,
+      cost: campaign.cost,
+      metrics: campaign.metrics,
+      totalLeads: stat.totalLeads,
+      convertedLeads: stat.convertedLeads,
+      cpl,
+      cpa
+    }
+  })
+
+  const rankedCampaigns = [...campaignMetrics].sort((a, b) => {
+    const aCpl = a.cpl ?? Number.POSITIVE_INFINITY
+    const bCpl = b.cpl ?? Number.POSITIVE_INFINITY
+    if (aCpl === bCpl) {
+      return (b.convertedLeads || 0) - (a.convertedLeads || 0)
+    }
+    return aCpl - bCpl
+  })
+
+  res.json({
+    timeSeries: timeSeries.map(day => ({
+      date: day._id,
+      totalLeads: day.totalLeads,
+      conversionRate: day.totalLeads === 0 ? 0 : (day.convertedLeads / day.totalLeads) * 100
+    })),
+    totals,
+    campaignMetrics,
+    rankedCampaigns
+  })
+}

--- a/backend/src/controllers/leadController.js
+++ b/backend/src/controllers/leadController.js
@@ -1,0 +1,82 @@
+import Lead from '../models/Lead.js'
+
+export const getLeads = async (req, res) => {
+  const leads = await Lead.find().populate('sourceCampaign').sort({ createdAt: -1 })
+  res.json(leads)
+}
+
+const sanitizeLeadPayload = (body) => {
+  const payload = { ...body }
+  if (typeof payload.fullName === 'string') {
+    payload.fullName = payload.fullName.trim()
+  }
+  if (typeof payload.phone === 'string') {
+    payload.phone = payload.phone.trim()
+  }
+  if (typeof payload.email === 'string') {
+    payload.email = payload.email.trim()
+    if (payload.email.length === 0) {
+      delete payload.email
+    }
+  }
+  if (typeof payload.notes === 'string' && payload.notes.trim().length === 0) {
+    delete payload.notes
+  }
+  if (!payload.sourceCampaign) {
+    delete payload.sourceCampaign
+  }
+  return payload
+}
+
+export const createLead = async (req, res) => {
+  const payload = sanitizeLeadPayload(req.body)
+
+  const duplicate = await Lead.findOne({ phone: payload.phone })
+  if (duplicate) {
+    return res.status(409).json({ message: 'A lead with this phone already exists' })
+  }
+
+  try {
+    const lead = await Lead.create(payload)
+    res.status(201).json(lead)
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(409).json({ message: 'A lead with this phone already exists' })
+    }
+    throw error
+  }
+}
+
+export const updateLead = async (req, res) => {
+  const { id } = req.params
+  const payload = sanitizeLeadPayload(req.body)
+
+  if (payload.phone) {
+    const duplicate = await Lead.findOne({ phone: payload.phone, _id: { $ne: id } })
+    if (duplicate) {
+      return res.status(409).json({ message: 'A lead with this phone already exists' })
+    }
+  }
+
+  try {
+    const lead = await Lead.findByIdAndUpdate(id, payload, { new: true, runValidators: true })
+    if (!lead) {
+      return res.status(404).json({ message: 'Lead not found' })
+    }
+    res.json(lead)
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(409).json({ message: 'A lead with this phone already exists' })
+    }
+    throw error
+  }
+}
+
+export const deleteLead = async (req, res) => {
+  const { id } = req.params
+  const lead = await Lead.findByIdAndDelete(id)
+  if (!lead) {
+    return res.status(404).json({ message: 'Lead not found' })
+  }
+  res.json({ message: 'Lead deleted' })
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,21 @@
+import dotenv from 'dotenv'
+import app from './app.js'
+import { connectDB } from './config/db.js'
+
+dotenv.config()
+
+const port = process.env.PORT || 5000
+
+const start = async () => {
+  try {
+    await connectDB()
+    app.listen(port, () => {
+      console.log(`Server running on port ${port}`)
+    })
+  } catch (error) {
+    console.error('Failed to start server', error)
+    process.exit(1)
+  }
+}
+
+start()

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,34 @@
+import jwt from 'jsonwebtoken'
+import User from '../models/User.js'
+
+export const authenticate = async (req, res, next) => {
+  const authHeader = req.headers.authorization
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Authentication required' })
+  }
+
+  const token = authHeader.split(' ')[1]
+  try {
+    const secret = process.env.JWT_SECRET
+    if (!secret) {
+      throw new Error('JWT_SECRET is not defined')
+    }
+    const payload = jwt.verify(token, secret)
+    const user = await User.findById(payload.id).select('-password')
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid token' })
+    }
+    req.user = user
+    next()
+  } catch (error) {
+    console.error(error)
+    res.status(401).json({ message: 'Invalid token' })
+  }
+}
+
+export const authorizeRoles = (...roles) => (req, res, next) => {
+  if (!roles.includes(req.user.role)) {
+    return res.status(403).json({ message: 'Access denied' })
+  }
+  next()
+}

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,0 +1,10 @@
+export const notFound = (req, res, next) => {
+  res.status(404).json({ message: 'Route not found' })
+}
+
+export const errorHandler = (err, req, res, next) => {
+  console.error(err)
+  const status = err.statusCode || 500
+  const message = err.message || 'Internal server error'
+  res.status(status).json({ message })
+}

--- a/backend/src/models/Campaign.js
+++ b/backend/src/models/Campaign.js
@@ -1,0 +1,46 @@
+import mongoose from 'mongoose'
+
+const metricsSchema = new mongoose.Schema({
+  reach: {
+    type: Number,
+    default: 0
+  },
+  impressions: {
+    type: Number,
+    default: 0
+  }
+}, { _id: false })
+
+const campaignSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  type: {
+    type: String,
+    required: true
+  },
+  startDate: {
+    type: Date,
+    required: true
+  },
+  cost: {
+    type: Number,
+    required: true,
+    min: 0
+  },
+  metrics: {
+    type: metricsSchema,
+    default: () => ({})
+  },
+  owner: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  }
+}, { timestamps: true })
+
+const Campaign = mongoose.model('Campaign', campaignSchema)
+
+export default Campaign

--- a/backend/src/models/Lead.js
+++ b/backend/src/models/Lead.js
@@ -1,0 +1,39 @@
+import mongoose from 'mongoose'
+
+const leadSchema = new mongoose.Schema({
+  fullName: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  phone: {
+    type: String,
+    required: true,
+    unique: true,
+    trim: true
+  },
+  email: {
+    type: String,
+    lowercase: true,
+    trim: true
+  },
+  status: {
+    type: String,
+    enum: ['New', 'In Progress', 'Converted', 'Lost'],
+    default: 'New'
+  },
+  notes: {
+    type: String,
+    trim: true
+  },
+  sourceCampaign: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Campaign'
+  }
+}, { timestamps: true })
+
+leadSchema.index({ phone: 1 }, { unique: true })
+
+const Lead = mongoose.model('Lead', leadSchema)
+
+export default Lead

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,0 +1,41 @@
+import mongoose from 'mongoose'
+import bcrypt from 'bcryptjs'
+
+const userSchema = new mongoose.Schema({
+  fullName: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  email: {
+    type: String,
+    required: true,
+    unique: true,
+    lowercase: true
+  },
+  password: {
+    type: String,
+    required: true,
+    minlength: 6
+  },
+  role: {
+    type: String,
+    enum: ['Admin', 'Data Entry'],
+    default: 'Data Entry'
+  }
+}, { timestamps: true })
+
+userSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next()
+  const salt = await bcrypt.genSalt(10)
+  this.password = await bcrypt.hash(this.password, salt)
+  next()
+})
+
+userSchema.methods.comparePassword = async function (candidate) {
+  return bcrypt.compare(candidate, this.password)
+}
+
+const User = mongoose.model('User', userSchema)
+
+export default User

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express'
+import { getProfile, login, register } from '../controllers/authController.js'
+import { authenticate } from '../middleware/auth.js'
+
+const router = Router()
+
+router.post('/register', register)
+router.post('/login', login)
+router.get('/me', authenticate, getProfile)
+
+export default router

--- a/backend/src/routes/campaignRoutes.js
+++ b/backend/src/routes/campaignRoutes.js
@@ -1,0 +1,14 @@
+import { Router } from 'express'
+import { createCampaign, deleteCampaign, getCampaigns, updateCampaign } from '../controllers/campaignController.js'
+import { authenticate } from '../middleware/auth.js'
+
+const router = Router()
+
+router.use(authenticate)
+
+router.get('/', getCampaigns)
+router.post('/', createCampaign)
+router.put('/:id', updateCampaign)
+router.delete('/:id', deleteCampaign)
+
+export default router

--- a/backend/src/routes/dashboardRoutes.js
+++ b/backend/src/routes/dashboardRoutes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express'
+import { getDashboardMetrics } from '../controllers/dashboardController.js'
+import { authenticate, authorizeRoles } from '../middleware/auth.js'
+
+const router = Router()
+
+router.use(authenticate, authorizeRoles('Admin'))
+
+router.get('/metrics', getDashboardMetrics)
+
+export default router

--- a/backend/src/routes/leadRoutes.js
+++ b/backend/src/routes/leadRoutes.js
@@ -1,0 +1,14 @@
+import { Router } from 'express'
+import { createLead, deleteLead, getLeads, updateLead } from '../controllers/leadController.js'
+import { authenticate } from '../middleware/auth.js'
+
+const router = Router()
+
+router.use(authenticate)
+
+router.get('/', getLeads)
+router.post('/', createLead)
+router.put('/:id', updateLead)
+router.delete('/:id', deleteLead)
+
+export default router

--- a/backend/src/utils/token.js
+++ b/backend/src/utils/token.js
@@ -1,0 +1,11 @@
+import jwt from 'jsonwebtoken'
+
+export const generateToken = (user) => {
+  const secret = process.env.JWT_SECRET
+  if (!secret) {
+    throw new Error('JWT_SECRET is not defined')
+  }
+  return jwt.sign({ id: user._id, role: user.role }, secret, {
+    expiresIn: '7d'
+  })
+}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000/api

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Marketing Performance Dashboard</title>
+  </head>
+  <body class="bg-background text-foreground">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "marketing-analytics-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-slot": "^1.0.2",
+    "axios": "^1.7.2",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.378.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.4.1",
+    "react-router-dom": "^6.23.0",
+    "recharts": "^2.9.0",
+    "tailwind-merge": "^2.2.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.4",
+    "tailwindcss-animate": "^1.0.7",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,93 @@
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
+import { useAuth } from './context/AuthContext'
+import LoginPage from './pages/LoginPage'
+import RegisterPage from './pages/RegisterPage'
+import DashboardPage from './pages/DashboardPage'
+import CampaignsPage from './pages/CampaignsPage'
+import LeadsPage from './pages/LeadsPage'
+import Sidebar from './components/layout/Sidebar'
+import Navbar from './components/layout/Navbar'
+import { Spinner } from './components/ui/spinner'
+
+const ProtectedRoute = ({ children, roles }) => {
+  const { user, loading } = useAuth()
+  const location = useLocation()
+
+  if (loading) {
+    return <Spinner />
+  }
+  if (!user) {
+    return <Navigate to="/login" replace state={{ from: location }} />
+  }
+  if (roles && !roles.includes(user.role)) {
+    return <Navigate to={user.role === 'Admin' ? '/dashboard' : '/leads'} replace />
+  }
+  return children
+}
+
+const AppLayout = ({ children }) => {
+  const { user, logout } = useAuth()
+  return (
+    <div className="flex min-h-screen bg-background text-foreground">
+      <Sidebar role={user?.role} />
+      <div className="flex flex-1 flex-col">
+        <Navbar user={user} onLogout={logout} />
+        <main className="flex-1 overflow-y-auto bg-muted/10 p-6">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}
+
+const HomeRedirect = () => {
+  const { user, loading } = useAuth()
+  if (loading) {
+    return <Spinner />
+  }
+  if (!user) return <Navigate to="/login" replace />
+  return <Navigate to={user.role === 'Admin' ? '/dashboard' : '/leads'} replace />
+}
+
+const App = () => {
+  return (
+    <Routes>
+      <Route path="/" element={<HomeRedirect />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route
+        path="/dashboard"
+        element={
+          <ProtectedRoute roles={['Admin']}>
+            <AppLayout>
+              <DashboardPage />
+            </AppLayout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/campaigns"
+        element={
+          <ProtectedRoute roles={['Admin', 'Data Entry']}>
+            <AppLayout>
+              <CampaignsPage />
+            </AppLayout>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/leads"
+        element={
+          <ProtectedRoute roles={['Admin', 'Data Entry']}>
+            <AppLayout>
+              <LeadsPage />
+            </AppLayout>
+          </ProtectedRoute>
+        }
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  )
+}
+
+export default App

--- a/frontend/src/components/layout/Navbar.jsx
+++ b/frontend/src/components/layout/Navbar.jsx
@@ -1,0 +1,31 @@
+import { Sun, Moon, LogOut } from 'lucide-react'
+import { Button } from '../ui/button'
+import { useTheme } from '../../hooks/useTheme'
+
+const Navbar = ({ user, onLogout }) => {
+  const { theme, toggleTheme } = useTheme()
+
+  return (
+    <header className="flex h-16 items-center justify-between border-b bg-background px-6">
+      <div>
+        <h1 className="text-xl font-semibold">Marketing Performance Dashboard</h1>
+        <p className="text-sm text-muted-foreground">Monitor campaigns and leads in real-time</p>
+      </div>
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme">
+          {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+        </Button>
+        <div className="text-right">
+          <div className="text-sm font-medium">{user?.fullName}</div>
+          <div className="text-xs text-muted-foreground">{user?.role}</div>
+        </div>
+        <Button variant="outline" size="sm" onClick={onLogout} className="flex items-center gap-2">
+          <LogOut className="h-4 w-4" />
+          Logout
+        </Button>
+      </div>
+    </header>
+  )
+}
+
+export default Navbar

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,0 +1,41 @@
+import { NavLink } from 'react-router-dom'
+import { BarChart2, FolderKanban, Users } from 'lucide-react'
+import { cn } from '../../lib/utils'
+
+const links = [
+  { to: '/dashboard', label: 'Dashboard', icon: BarChart2, roles: ['Admin'] },
+  { to: '/campaigns', label: 'Campaigns', icon: FolderKanban, roles: ['Admin', 'Data Entry'] },
+  { to: '/leads', label: 'Leads', icon: Users, roles: ['Admin', 'Data Entry'] }
+]
+
+const Sidebar = ({ role }) => {
+  return (
+    <aside className="flex h-full w-64 flex-col border-r bg-background p-6">
+      <div className="mb-8 text-2xl font-semibold">Marketing IQ</div>
+      <nav className="flex flex-col space-y-2">
+        {links
+          .filter(link => !role || link.roles.includes(role))
+          .map(link => {
+            const Icon = link.icon
+            return (
+              <NavLink
+                key={link.to}
+                to={link.to}
+                className={({ isActive }) =>
+                  cn(
+                    'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-secondary hover:text-secondary-foreground',
+                    isActive && 'bg-primary text-primary-foreground'
+                  )
+                }
+              >
+                <Icon className="h-4 w-4" />
+                {link.label}
+              </NavLink>
+            )
+          })}
+      </nav>
+    </aside>
+  )
+}
+
+export default Sidebar

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva } from 'class-variance-authority'
+import { cn } from '../../lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        destructive: 'bg-red-600 text-white hover:bg-red-600/90'
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default'
+    }
+  }
+)
+
+const Button = React.forwardRef(({ className, variant, size, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'button'
+  return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+})
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }

--- a/frontend/src/components/ui/card.jsx
+++ b/frontend/src/components/ui/card.jsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import { cn } from '../../lib/utils'
+
+const Card = React.forwardRef(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)} {...props} />
+))
+Card.displayName = 'Card'
+
+const CardHeader = ({ className, ...props }) => (
+  <div className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+)
+CardHeader.displayName = 'CardHeader'
+
+const CardTitle = ({ className, ...props }) => (
+  <h3 className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+)
+CardTitle.displayName = 'CardTitle'
+
+const CardContent = ({ className, ...props }) => (
+  <div className={cn('p-6 pt-0', className)} {...props} />
+)
+CardContent.displayName = 'CardContent'
+
+const CardDescription = ({ className, ...props }) => (
+  <p className={cn('text-sm text-muted-foreground', className)} {...props} />
+)
+CardDescription.displayName = 'CardDescription'
+
+export { Card, CardHeader, CardTitle, CardContent, CardDescription }

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -1,0 +1,58 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import { cn } from '../../lib/utils'
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = ({ className, ...props }) => (
+  <DialogPrimitive.Overlay
+    className={cn('fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0', className)}
+    {...props}
+  />
+)
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = ({ className, children, ...props }) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      className={cn('fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95', className)}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+)
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+)
+DialogHeader.displayName = 'DialogHeader'
+
+const DialogTitle = ({ className, ...props }) => (
+  <DialogPrimitive.Title className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+)
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = ({ className, ...props }) => (
+  <DialogPrimitive.Description className={cn('text-sm text-muted-foreground', className)} {...props} />
+)
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+const DialogFooter = ({ className, ...props }) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+)
+DialogFooter.displayName = 'DialogFooter'
+
+export { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose }

--- a/frontend/src/components/ui/input.jsx
+++ b/frontend/src/components/ui/input.jsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import { cn } from '../../lib/utils'
+
+const Input = React.forwardRef(({ className, type = 'text', ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Input.displayName = 'Input'
+
+export { Input }

--- a/frontend/src/components/ui/label.jsx
+++ b/frontend/src/components/ui/label.jsx
@@ -1,0 +1,13 @@
+import * as React from 'react'
+import { cn } from '../../lib/utils'
+
+const Label = React.forwardRef(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+    {...props}
+  />
+))
+Label.displayName = 'Label'
+
+export { Label }

--- a/frontend/src/components/ui/spinner.jsx
+++ b/frontend/src/components/ui/spinner.jsx
@@ -1,0 +1,7 @@
+const Spinner = () => (
+  <div className="flex items-center justify-center py-6">
+    <div className="h-10 w-10 animate-spin rounded-full border-4 border-primary/30 border-t-primary" aria-label="Loading" />
+  </div>
+)
+
+export { Spinner }

--- a/frontend/src/components/ui/table.jsx
+++ b/frontend/src/components/ui/table.jsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import { cn } from '../../lib/utils'
+
+const Table = React.forwardRef(({ className, ...props }, ref) => (
+  <div className="w-full overflow-auto">
+    <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+  </div>
+))
+Table.displayName = 'Table'
+
+const TableHeader = ({ className, ...props }) => (
+  <thead className={cn('[&_tr]:border-b', className)} {...props} />
+)
+TableHeader.displayName = 'TableHeader'
+
+const TableBody = ({ className, ...props }) => (
+  <tbody className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+)
+TableBody.displayName = 'TableBody'
+
+const TableRow = ({ className, ...props }) => (
+  <tr className={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', className)} {...props} />
+)
+TableRow.displayName = 'TableRow'
+
+const TableHead = ({ className, ...props }) => (
+  <th className={cn('h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0', className)} {...props} />
+)
+TableHead.displayName = 'TableHead'
+
+const TableCell = ({ className, ...props }) => (
+  <td className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)} {...props} />
+)
+TableCell.displayName = 'TableCell'
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell }

--- a/frontend/src/components/ui/textarea.jsx
+++ b/frontend/src/components/ui/textarea.jsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { cn } from '../../lib/utils'
+
+const Textarea = React.forwardRef(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        'flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Textarea.displayName = 'Textarea'
+
+export { Textarea }

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import axios from 'axios'
+import api from '../services/api'
+
+const STORAGE_KEY = 'marketing-dashboard-auth'
+
+const AuthContext = createContext()
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null)
+  const [token, setToken] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const stored = typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null
+    if (stored) {
+      const parsed = JSON.parse(stored)
+      setUser(parsed.user)
+      setToken(parsed.token)
+      axios.defaults.headers.common.Authorization = `Bearer ${parsed.token}`
+      api.defaults.headers.common.Authorization = `Bearer ${parsed.token}`
+    }
+    setLoading(false)
+  }, [])
+
+  const login = (data) => {
+    setUser(data.user)
+    setToken(data.token)
+    axios.defaults.headers.common.Authorization = `Bearer ${data.token}`
+    api.defaults.headers.common.Authorization = `Bearer ${data.token}`
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  }
+
+  const logout = () => {
+    setUser(null)
+    setToken(null)
+    delete axios.defaults.headers.common.Authorization
+    delete api.defaults.headers.common.Authorization
+    localStorage.removeItem(STORAGE_KEY)
+  }
+
+  const value = useMemo(() => ({ user, token, login, logout, loading }), [user, token, loading])
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/frontend/src/hooks/useTheme.js
+++ b/frontend/src/hooks/useTheme.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'marketing-dashboard-theme'
+
+export const useTheme = () => {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window === 'undefined') return 'light'
+    return localStorage.getItem(STORAGE_KEY) || 'light'
+  })
+
+  useEffect(() => {
+    const root = window.document.documentElement
+    if (theme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+    localStorage.setItem(STORAGE_KEY, theme)
+  }, [theme])
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'))
+  }
+
+  return { theme, toggleTheme }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,54 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 224 71.4% 4.1%;
+  --card: 0 0% 100%;
+  --card-foreground: 224 71.4% 4.1%;
+  --muted: 220 14% 96%;
+  --muted-foreground: 215 16.3% 46.9%;
+  --accent: 210 15% 90%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --primary: 262.1 83.3% 57.8%;
+  --primary-foreground: 210 20% 98%;
+  --secondary: 210 15% 90%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --border: 214 31% 91%;
+  --input: 214 31% 91%;
+  --ring: 215 20.2% 65.1%;
+  --radius: 0.75rem;
+}
+
+.dark {
+  --background: 222.2 47.4% 11.2%;
+  --foreground: 210 20% 98%;
+  --card: 222.2 47.4% 11.2%;
+  --card-foreground: 210 20% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 20% 98%;
+  --primary: 263.4 70% 50.4%;
+  --primary-foreground: 210 20% 98%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 20% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 263.4 70% 50.4%;
+}
+
+body {
+  background-color: hsl(var(--background));
+  color: hsl(var(--foreground));
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: hsla(var(--foreground), 0.15);
+  border-radius: 9999px;
+}

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn (...inputs) {
+  return twMerge(clsx(inputs))
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './index.css'
+import { AuthProvider } from './context/AuthContext'
+import { Toaster } from 'react-hot-toast'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+        <Toaster position="top-right" />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/frontend/src/pages/CampaignsPage.jsx
+++ b/frontend/src/pages/CampaignsPage.jsx
@@ -1,0 +1,217 @@
+import { useEffect, useState } from 'react'
+import toast from 'react-hot-toast'
+import { Plus } from 'lucide-react'
+import { Button } from '../components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger, DialogClose } from '../components/ui/dialog'
+import { Input } from '../components/ui/input'
+import { Label } from '../components/ui/label'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table'
+import { Spinner } from '../components/ui/spinner'
+import api from '../services/api'
+
+const defaultForm = {
+  name: '',
+  type: '',
+  startDate: '',
+  cost: '',
+  metrics: {
+    reach: '',
+    impressions: ''
+  }
+}
+
+const CampaignsPage = () => {
+  const [campaigns, setCampaigns] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [editing, setEditing] = useState(null)
+  const [form, setForm] = useState(() => ({ ...defaultForm, metrics: { ...defaultForm.metrics } }))
+
+  const loadCampaigns = async () => {
+    setLoading(true)
+    try {
+      const { data } = await api.get('/campaigns')
+      setCampaigns(data)
+    } catch (error) {
+      toast.error(error.message || 'Failed to load campaigns')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadCampaigns()
+  }, [])
+
+  const handleOpen = (campaign = null) => {
+    setEditing(campaign)
+    if (campaign) {
+      setForm({
+        name: campaign.name,
+        type: campaign.type,
+        startDate: campaign.startDate?.slice(0, 10) || '',
+        cost: campaign.cost,
+        metrics: {
+          reach: campaign.metrics?.reach ?? '',
+          impressions: campaign.metrics?.impressions ?? ''
+        }
+      })
+    } else {
+      setForm({ ...defaultForm, metrics: { ...defaultForm.metrics } })
+    }
+    setOpen(true)
+  }
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    if (name === 'reach' || name === 'impressions') {
+      setForm(prev => ({ ...prev, metrics: { ...prev.metrics, [name]: value } }))
+    } else {
+      setForm(prev => ({ ...prev, [name]: value }))
+    }
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    try {
+      if (editing) {
+        await api.put(`/campaigns/${editing._id}`, {
+          ...form,
+          cost: Number(form.cost),
+          metrics: {
+            reach: Number(form.metrics.reach),
+            impressions: Number(form.metrics.impressions)
+          }
+        })
+        toast.success('Campaign updated')
+      } else {
+        await api.post('/campaigns', {
+          ...form,
+          cost: Number(form.cost),
+          metrics: {
+            reach: Number(form.metrics.reach),
+            impressions: Number(form.metrics.impressions)
+          }
+        })
+        toast.success('Campaign created')
+      }
+      setOpen(false)
+      loadCampaigns()
+    } catch (error) {
+      toast.error(error.message || 'Failed to save campaign')
+    }
+  }
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this campaign?')) return
+    try {
+      await api.delete(`/campaigns/${id}`)
+      toast.success('Campaign deleted')
+      loadCampaigns()
+    } catch (error) {
+      toast.error(error.message || 'Failed to delete campaign')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">Campaigns</h2>
+          <p className="text-sm text-muted-foreground">Manage marketing initiatives and optimize spend.</p>
+        </div>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button onClick={() => handleOpen(null)}>
+              <Plus className="mr-2 h-4 w-4" /> New Campaign
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{editing ? 'Edit Campaign' : 'Create Campaign'}</DialogTitle>
+              <DialogDescription>Fill in the details below to {editing ? 'update' : 'create'} a campaign.</DialogDescription>
+            </DialogHeader>
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              <div className="space-y-2">
+                <Label htmlFor="name">Campaign Name</Label>
+                <Input id="name" name="name" required value={form.name} onChange={handleChange} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="type">Type</Label>
+                <Input id="type" name="type" required value={form.type} onChange={handleChange} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="startDate">Start Date</Label>
+                <Input id="startDate" name="startDate" type="date" required value={form.startDate} onChange={handleChange} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cost">Budget (USD)</Label>
+                <Input id="cost" name="cost" type="number" step="0.01" required value={form.cost} onChange={handleChange} />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="reach">Reach</Label>
+                  <Input id="reach" name="reach" type="number" value={form.metrics.reach} onChange={handleChange} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="impressions">Impressions</Label>
+                  <Input id="impressions" name="impressions" type="number" value={form.metrics.impressions} onChange={handleChange} />
+                </div>
+              </div>
+              <DialogFooter className="gap-2">
+                <DialogClose asChild>
+                  <Button type="button" variant="outline">
+                    Cancel
+                  </Button>
+                </DialogClose>
+                <Button type="submit">{editing ? 'Save changes' : 'Create campaign'}</Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {loading ? (
+        <Spinner />
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Type</TableHead>
+              <TableHead>Start Date</TableHead>
+              <TableHead>Cost</TableHead>
+              <TableHead>Reach</TableHead>
+              <TableHead>Impressions</TableHead>
+              <TableHead>Owner</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {campaigns.map(campaign => (
+              <TableRow key={campaign._id}>
+                <TableCell className="font-medium">{campaign.name}</TableCell>
+                <TableCell>{campaign.type}</TableCell>
+                <TableCell>{campaign.startDate ? new Date(campaign.startDate).toLocaleDateString() : '—'}</TableCell>
+                <TableCell>${Number(campaign.cost ?? 0).toLocaleString()}</TableCell>
+                <TableCell>{campaign.metrics?.reach ?? '—'}</TableCell>
+                <TableCell>{campaign.metrics?.impressions ?? '—'}</TableCell>
+                <TableCell>{campaign.owner?.fullName ?? '—'}</TableCell>
+                <TableCell className="text-right space-x-2">
+                  <Button size="sm" variant="outline" onClick={() => handleOpen(campaign)}>
+                    Edit
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={() => handleDelete(campaign._id)}>
+                    Delete
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}
+
+export default CampaignsPage

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,0 +1,186 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../components/ui/card'
+import { Spinner } from '../components/ui/spinner'
+import api from '../services/api'
+import toast from 'react-hot-toast'
+import { Button } from '../components/ui/button'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid
+} from 'recharts'
+
+const ranges = {
+  last7: { label: 'Last 7 days', days: 7 },
+  last30: { label: 'Last 30 days', days: 30 },
+  quarter: { label: 'Last 90 days', days: 90 }
+}
+
+const DashboardPage = () => {
+  const [range, setRange] = useState('last30')
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(false)
+
+  const params = useMemo(() => {
+    const { days } = ranges[range]
+    const end = new Date()
+    const start = new Date()
+    start.setDate(end.getDate() - days)
+    return {
+      startDate: start.toISOString(),
+      endDate: end.toISOString()
+    }
+  }, [range])
+
+  const loadMetrics = async () => {
+    setLoading(true)
+    try {
+      const { data: metrics } = await api.get('/dashboard/metrics', { params })
+      setData(metrics)
+    } catch (error) {
+      toast.error(error.message || 'Failed to load metrics')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadMetrics()
+  }, [range])
+
+  if (loading && !data) {
+    return <Spinner />
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center gap-3">
+        {Object.entries(ranges).map(([key, value]) => (
+          <Button key={key} variant={range === key ? 'default' : 'secondary'} onClick={() => setRange(key)}>
+            {value.label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardTitle>Total Leads</CardTitle>
+            <CardDescription>All leads captured in the selected period</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">{data?.totals.totalLeads ?? 0}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Converted Leads</CardTitle>
+            <CardDescription>Number of leads that converted</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">{data?.totals.convertedLeads ?? 0}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Conversion Rate</CardTitle>
+            <CardDescription>Percentage of leads converted</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">{(data?.totals.conversionRate ?? 0).toFixed(1)}%</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Lead Growth & Conversion</CardTitle>
+          <CardDescription>Visualize lead generation performance over time.</CardDescription>
+        </CardHeader>
+        <CardContent className="h-80">
+          {loading ? (
+            <Spinner />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={data?.timeSeries || []}>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey="date" stroke="hsl(var(--foreground))" tick={{ fontSize: 12 }} />
+                <YAxis yAxisId="left" stroke="hsl(var(--foreground))" tick={{ fontSize: 12 }} allowDecimals={false} />
+                <YAxis yAxisId="right" orientation="right" stroke="hsl(var(--foreground))" tick={{ fontSize: 12 }} domain={[0, 100]} />
+                <Tooltip
+                  contentStyle={{ backgroundColor: 'hsl(var(--background))', borderRadius: 8, border: '1px solid hsl(var(--border))' }}
+                />
+                <Line type="monotone" yAxisId="left" dataKey="totalLeads" stroke="hsl(var(--primary))" strokeWidth={2} />
+                <Line type="monotone" yAxisId="right" dataKey="conversionRate" stroke="hsl(var(--secondary-foreground))" strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Campaign Performance</CardTitle>
+          <CardDescription>Cost efficiency and conversions by campaign.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-3">
+            {data?.campaignMetrics?.map(campaign => {
+              const cost = Number(campaign.cost ?? 0)
+              return (
+                <div key={campaign.id} className="rounded-lg border bg-background p-4 shadow-sm">
+                  <div className="text-sm font-semibold">{campaign.name}</div>
+                  <div className="text-xs text-muted-foreground">{campaign.type}</div>
+                  <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                    <span className="text-muted-foreground">Cost</span>
+                    <span className="text-right font-medium">${cost.toLocaleString()}</span>
+                    <span className="text-muted-foreground">Leads</span>
+                    <span className="text-right font-medium">{campaign.totalLeads}</span>
+                    <span className="text-muted-foreground">Converted</span>
+                    <span className="text-right font-medium">{campaign.convertedLeads}</span>
+                    <span className="text-muted-foreground">CPL</span>
+                    <span className="text-right font-medium">{campaign.cpl ? `$${campaign.cpl.toFixed(2)}` : '—'}</span>
+                    <span className="text-muted-foreground">CPA</span>
+                    <span className="text-right font-medium">{campaign.cpa ? `$${campaign.cpa.toFixed(2)}` : '—'}</span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+          <div>
+            <h3 className="mb-2 text-lg font-semibold">Top Campaigns by CPL</h3>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Campaign</TableHead>
+                  <TableHead>Leads</TableHead>
+                  <TableHead>Converted</TableHead>
+                  <TableHead>CPL</TableHead>
+                  <TableHead>CPA</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data?.rankedCampaigns?.map(campaign => (
+                  <TableRow key={campaign.id}>
+                    <TableCell>{campaign.name}</TableCell>
+                    <TableCell>{campaign.totalLeads}</TableCell>
+                    <TableCell>{campaign.convertedLeads}</TableCell>
+                    <TableCell>{campaign.cpl ? `$${campaign.cpl.toFixed(2)}` : '—'}</TableCell>
+                    <TableCell>{campaign.cpa ? `$${campaign.cpa.toFixed(2)}` : '—'}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default DashboardPage

--- a/frontend/src/pages/LeadsPage.jsx
+++ b/frontend/src/pages/LeadsPage.jsx
@@ -1,0 +1,224 @@
+import { useEffect, useState } from 'react'
+import toast from 'react-hot-toast'
+import { Plus } from 'lucide-react'
+import { Button } from '../components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger, DialogClose } from '../components/ui/dialog'
+import { Input } from '../components/ui/input'
+import { Label } from '../components/ui/label'
+import { Textarea } from '../components/ui/textarea'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table'
+import { Spinner } from '../components/ui/spinner'
+import api from '../services/api'
+
+const statuses = ['New', 'In Progress', 'Converted', 'Lost']
+
+const defaultForm = {
+  fullName: '',
+  phone: '',
+  email: '',
+  status: 'New',
+  notes: '',
+  sourceCampaign: ''
+}
+
+const LeadsPage = () => {
+  const [leads, setLeads] = useState([])
+  const [campaigns, setCampaigns] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [editing, setEditing] = useState(null)
+  const [form, setForm] = useState(defaultForm)
+
+  const loadData = async () => {
+    setLoading(true)
+    try {
+      const [leadsRes, campaignsRes] = await Promise.all([
+        api.get('/leads'),
+        api.get('/campaigns')
+      ])
+      setLeads(leadsRes.data)
+      setCampaigns(campaignsRes.data)
+    } catch (error) {
+      toast.error(error.message || 'Failed to load leads')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  const handleOpen = (lead = null) => {
+    setEditing(lead)
+    if (lead) {
+      setForm({
+        fullName: lead.fullName,
+        phone: lead.phone,
+        email: lead.email || '',
+        status: lead.status,
+        notes: lead.notes || '',
+        sourceCampaign: lead.sourceCampaign?._id || ''
+      })
+    } else {
+      setForm(defaultForm)
+    }
+    setOpen(true)
+  }
+
+  const handleChange = (e) => {
+    setForm(prev => ({ ...prev, [e.target.name]: e.target.value }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    try {
+      const payload = { ...form }
+      if (!payload.sourceCampaign) delete payload.sourceCampaign
+
+      if (editing) {
+        await api.put(`/leads/${editing._id}`, payload)
+        toast.success('Lead updated')
+      } else {
+        await api.post('/leads', payload)
+        toast.success('Lead created')
+      }
+      setOpen(false)
+      loadData()
+    } catch (error) {
+      toast.error(error.message || 'Failed to save lead')
+    }
+  }
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this lead?')) return
+    try {
+      await api.delete(`/leads/${id}`)
+      toast.success('Lead deleted')
+      loadData()
+    } catch (error) {
+      toast.error(error.message || 'Failed to delete lead')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold">Leads</h2>
+          <p className="text-sm text-muted-foreground">Capture and nurture prospects effectively.</p>
+        </div>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button onClick={() => handleOpen(null)}>
+              <Plus className="mr-2 h-4 w-4" /> New Lead
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{editing ? 'Edit Lead' : 'Create Lead'}</DialogTitle>
+              <DialogDescription>Provide the lead details below.</DialogDescription>
+            </DialogHeader>
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              <div className="space-y-2">
+                <Label htmlFor="fullName">Full Name</Label>
+                <Input id="fullName" name="fullName" required value={form.fullName} onChange={handleChange} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="phone">Phone</Label>
+                <Input id="phone" name="phone" required value={form.phone} onChange={handleChange} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input id="email" name="email" type="email" value={form.email} onChange={handleChange} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="status">Status</Label>
+                <select
+                  id="status"
+                  name="status"
+                  value={form.status}
+                  onChange={handleChange}
+                  className="h-10 w-full rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {statuses.map(status => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="sourceCampaign">Source Campaign</Label>
+                <select
+                  id="sourceCampaign"
+                  name="sourceCampaign"
+                  value={form.sourceCampaign}
+                  onChange={handleChange}
+                  className="h-10 w-full rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <option value="">None</option>
+                  {campaigns.map(campaign => (
+                    <option key={campaign._id} value={campaign._id}>
+                      {campaign.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="notes">Notes</Label>
+                <Textarea id="notes" name="notes" value={form.notes} onChange={handleChange} rows={3} />
+              </div>
+              <DialogFooter className="gap-2">
+                <DialogClose asChild>
+                  <Button type="button" variant="outline">
+                    Cancel
+                  </Button>
+                </DialogClose>
+                <Button type="submit">{editing ? 'Save changes' : 'Create lead'}</Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {loading ? (
+        <Spinner />
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Full Name</TableHead>
+              <TableHead>Phone</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Source Campaign</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {leads.map(lead => (
+              <TableRow key={lead._id}>
+                <TableCell className="font-medium">{lead.fullName}</TableCell>
+                <TableCell>{lead.phone}</TableCell>
+                <TableCell>{lead.email || '—'}</TableCell>
+                <TableCell>{lead.status}</TableCell>
+                <TableCell>{lead.sourceCampaign?.name || '—'}</TableCell>
+                <TableCell className="text-right space-x-2">
+                  <Button size="sm" variant="outline" onClick={() => handleOpen(lead)}>
+                    Edit
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={() => handleDelete(lead._id)}>
+                    Delete
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}
+
+export default LeadsPage

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom'
+import toast from 'react-hot-toast'
+import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
+import { Label } from '../components/ui/label'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../components/ui/card'
+import { useAuth } from '../context/AuthContext'
+import api from '../services/api'
+
+const LoginPage = () => {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { login, user } = useAuth()
+  const [form, setForm] = useState({ email: '', password: '' })
+  const [loading, setLoading] = useState(false)
+
+  if (user) {
+    return <Navigate to="/" replace />
+  }
+
+  const handleChange = (e) => {
+    setForm(prev => ({ ...prev, [e.target.name]: e.target.value }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      const { data } = await api.post('/auth/login', form)
+      login(data)
+      toast.success('Logged in successfully')
+      const from = location.state?.from?.pathname || '/'
+      navigate(from, { replace: true })
+    } catch (error) {
+      toast.error(error.message || 'Failed to login')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/30 p-6">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Welcome back</CardTitle>
+          <CardDescription>Enter your credentials to access the dashboard.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" name="email" type="email" required value={form.email} onChange={handleChange} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input id="password" name="password" type="password" required value={form.password} onChange={handleChange} />
+            </div>
+            <Button className="w-full" type="submit" disabled={loading}>
+              {loading ? 'Signing in...' : 'Sign in'}
+            </Button>
+          </form>
+          <p className="mt-4 text-center text-sm text-muted-foreground">
+            Don&apos;t have an account?{' '}
+            <Link to="/register" className="text-primary hover:underline">
+              Register
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default LoginPage

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+import { Link, Navigate, useNavigate } from 'react-router-dom'
+import toast from 'react-hot-toast'
+import { Button } from '../components/ui/button'
+import { Input } from '../components/ui/input'
+import { Label } from '../components/ui/label'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../components/ui/card'
+import { useAuth } from '../context/AuthContext'
+import api from '../services/api'
+
+const RegisterPage = () => {
+  const navigate = useNavigate()
+  const { login, user } = useAuth()
+  const [form, setForm] = useState({ fullName: '', email: '', password: '', role: 'Data Entry' })
+  const [loading, setLoading] = useState(false)
+
+  if (user) {
+    return <Navigate to="/" replace />
+  }
+
+  const handleChange = (e) => {
+    setForm(prev => ({ ...prev, [e.target.name]: e.target.value }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      const { data } = await api.post('/auth/register', form)
+      login(data)
+      toast.success('Account created successfully')
+      navigate('/', { replace: true })
+    } catch (error) {
+      toast.error(error.message || 'Failed to register')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/30 p-6">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Create an account</CardTitle>
+          <CardDescription>Start tracking your marketing performance.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <Label htmlFor="fullName">Full Name</Label>
+              <Input id="fullName" name="fullName" required value={form.fullName} onChange={handleChange} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input id="email" name="email" type="email" required value={form.email} onChange={handleChange} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input id="password" name="password" type="password" required value={form.password} onChange={handleChange} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="role">Role</Label>
+              <select
+                id="role"
+                name="role"
+                value={form.role}
+                onChange={handleChange}
+                className="h-10 w-full rounded-md border border-input bg-transparent px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <option value="Admin">Admin</option>
+                <option value="Data Entry">Data Entry</option>
+              </select>
+            </div>
+            <Button className="w-full" type="submit" disabled={loading}>
+              {loading ? 'Creating account...' : 'Create account'}
+            </Button>
+          </form>
+          <p className="mt-4 text-center text-sm text-muted-foreground">
+            Already have an account?{' '}
+            <Link to="/login" className="text-primary hover:underline">
+              Sign in
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default RegisterPage

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,17 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api'
+})
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.data?.message) {
+      error.message = error.response.data.message
+    }
+    return Promise.reject(error)
+  }
+)
+
+export default api

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,47 @@
+import animate from 'tailwindcss-animate'
+
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: 'class',
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))'
+        },
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))'
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))'
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))'
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))'
+        }
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)'
+      }
+    }
+  },
+  plugins: [animate]
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})


### PR DESCRIPTION
## Summary
- sanitize lead payloads before persisting them to MongoDB
- perform explicit duplicate phone checks prior to creating or updating leads
- tighten the lead schema with trim/lowercase settings for key fields

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68df0d7b6fc48328bdc0afaf7ce0b427